### PR TITLE
fixes: `search_filter` can not be `None` in ldap3; add `flask-login` requires;

### DIFF
--- a/flask_ldap_login/__init__.py
+++ b/flask_ldap_login/__init__.py
@@ -258,9 +258,9 @@ class LDAPLoginManager(object):
             return None
 
         direct_search_result = direct_conn.search(
-            search_base=user, 
-            search_filter=None, 
-            search_scope=scope, 
+            search_base=user,
+            search_filter='(objectClass=*)',
+            search_scope=scope,
             attributes=self.attrlist)
 
         if not direct_search_result:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!env python
 from setuptools import setup, find_packages
 
 
@@ -13,6 +14,7 @@ setup(
     zip_safe=False,
 
     install_requires=['flask',
+                      'flask-login',
                       'flask-wtf',
                       'ldap3'
                       ],


### PR DESCRIPTION
fixes: `search_filter` can not be `None` in ldap3; add `flask-login` requires;